### PR TITLE
Ensure aria2 availability and add curl/wget fallback

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,6 +50,20 @@ else
   fi
 fi
 
+# Ensure aria2 is installed for model downloads
+if ! command -v aria2c >/dev/null 2>&1; then
+  echo "aria2 not found. Attempting to install..."
+  if [ "$(uname)" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+    brew install aria2
+  elif [ "$(uname)" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y aria2
+  else
+    echo "Please install aria2 manually."
+    exit 1
+  fi
+fi
+
 # Download models
 chmod +x tools/dlmodels.sh
 ./tools/dlmodels.sh


### PR DESCRIPTION
## Summary
- install aria2 automatically in run.sh when missing
- allow model downloads with curl or wget if aria2c isn't available

## Testing
- `bash -n run.sh`
- `bash -n tools/dlmodels.sh`
- `./tools/dlmodels.sh >/tmp/dlmodels.log 2>&1 ; tail -n 20 /tmp/dlmodels.log` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a6f255c8321ad0269b58068a674