### PR TITLE
fix: enable GPU in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,7 @@ services:
       # - ./dataset:/app/dataset # you can use this folder in order to provide your dataset for model training
     ports:
       - 7865:7865
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
+    deploy: {}
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
## Summary
- replace deploy resources with runtime-based GPU access in docker-compose

## Testing
- `docker-compose config`
- `docker run --rm --gpus all nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 nvidia-smi` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a6d8a7c8321bf4275ede0b5f4a8