### PR TITLE
chore: drop python-dev from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa
 
 # Install Python 3.9 and pip
 RUN apt-get update && \
-    apt-get install -y build-essential python-dev python3-dev python3.9-distutils python3.9-dev python3.9 curl && \
+    apt-get install -y build-essential python3-dev python3.9-distutils python3.9-dev python3.9 curl && \
     apt-get clean && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
     curl https://bootstrap.pypa.io/get-pip.py | python3.9


### PR DESCRIPTION
## Summary
- remove deprecated `python-dev` from Dockerfile, keeping only Python 3 packages

## Testing
- `pytest`
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a6b03b88321849f941684d8745e