### PR TITLE
Install PyTorch with CUDA during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
 
 RUN python3 -m pip install --upgrade pip==24.0
+RUN python3 -m pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/pretrained_v2/D40k.pth -d assets/pretrained_v2/ -o D40k.pth


### PR DESCRIPTION
## Summary
- install torch, torchvision, and torchaudio CUDA wheels after upgrading pip in the Docker image

## Testing
- `pytest -q`
- `docker build . -t rvc-webui:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a699b7883219dad6819b0a14ab4